### PR TITLE
Compiler warning fixes

### DIFF
--- a/io_lib/cram_io.c
+++ b/io_lib/cram_io.c
@@ -3024,7 +3024,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     mFILE *mf;
 
     if (fd->verbose)
-	fprintf(stderr, "cram_populate_ref on fd %p, id %d\n", fd, id);
+	fprintf(stderr, "cram_populate_ref on fd %p, id %d\n", (void *)fd, id);
 
     if (!ref_path)
 	ref_path = ".";

--- a/progs/cram_dump.c
+++ b/progs/cram_dump.c
@@ -157,7 +157,8 @@ void dump_name_block(cram_block *b, int verbose) {
 }
 
 void dump_tag_block(cram_block *b, int verbose) {
-    return dump_core_block(b, verbose);
+    dump_core_block(b, verbose);
+    return;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Hi,

I fixed 2 compiler warnings in the io_lib code.

Which version of the C language is the io_lib project using ?

Also, there are **2 warnings** where I am not sure what is the correct thing to do:

**Warning 1: macro itf8_put at line 105 in file cram_io.h**

../io_lib/cram_io.h:105:79: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:139: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:222: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:307: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:307: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:336: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:358: warning: overflow in implicit constant conversion [-Woverflow]
../io_lib/cram_io.h:105:380: warning: overflow in implicit constant conversion [-Woverflow]

Line 105 of this file is huge !

#define itf8_put(c,v) ((!((v)&~0x7f))?((c)[0]=(v),1):(!((v)&~0x3fff))?((c)[0]=((v)>>8)|0x80,(c)[1]=(v)&0xff,2):(!((v)&~0x1fffff))?((c)[0]=((v)>>16)|0xc0,(c)[1]=((v)>>8)&0xff,(c)[2]=(v)&0xff,3):(!((v)&~0xfffffff))?((c)[0]=((v)>>24)|0xe0,(c)[1]=((v)>>16)&0xff,(c)[2]=((v)>>8)&0xff,(c)[3]=(v)&0xff,4):((c)[0]=0xf0|(((v)>>28)&0xff),(c)[1]=((v)>>20)&0xff,(c)[2]=((v)>>12)&0xff,(c)[3]=((v)>>4)&0xff,(c)[4]=(v)&0xf,5))

There are integers c and v. I don't know their width though...

I know that it puts something (v for value?). That's all I know.

**Warning 2: function ltf8_put at line 929 in file cram_io.c**

cram_io.c:929:10: warning: overflow in implicit constant conversion [-Woverflow]

Code:
in int ltf8_put(char *cp, int64_t val) {
...
    *cp++ = 0xff;

argument declaration: char *cp

This snippet prints -1 in stdout:

#include <stdio.h>

int main() {
    char c = 0xff;
    printf("%d", c);
}

If the goal is to set *cp at value -1, maybe it is better to assign -1 instead of 0xff.

