### PR TITLE
Updated htscodecs module to version 1.0.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "htscodecs"]
 	path = htscodecs
-	url = https://github.com/jkbonfield/htscodecs.git
+	url = https://github.com/samtools/htscodecs.git
 	ignore = untracked


### PR DESCRIPTION
The upstream master repository for this has also now changed, from jkbonfield/htscodecs to samtools/htscodecs.  (The jkbonfield one still exists as I use it for making PRs against the canonical copy at samtools, but the master branch will almost certainly not be kept up to date.)

[ PR for purposes of getting CI to fire. ]