### PR TITLE
Update files for release 1.15.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,21 @@
+Version 1.15.0 (14th April 2023)
+--------------
+
+Version number bumped to reflect the official status of CRAM 3.1.
+
+Updates:
+
+* Formally accept CRAM 3.1 as an official standard.  Warning removed.
+  For best compatibility CRAM 3.0 is still the default CRAM, but use
+  "-V3.1" to specify the version.
+
+* Updated to latest htscodecs.  This has a significant speed
+  improvement in encoding with fqzcomp (enabled in "-X small" profile).
+
+  Tested on a NovaSeq dataset, encoding from BAM to CRAM was 27% faster.
+  Decoding a CRAM with fqzcomp is also around 6% faster.
+
+
 Version 1.14.15 (6th December 2022)
 ---------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(io_lib, 1.14.15)
+AC_INIT(io_lib, 1.15.0)
 IOLIB_VERSION=$PACKAGE_VERSION
 IOLIB_VERSION_MAJOR=`expr "$PACKAGE_VERSION" : '\([[0-9]]*\)'`
 IOLIB_VERSION_MINOR=`expr "$PACKAGE_VERSION" : '[[0-9]]*\.\([[0-9]]*\)'`
@@ -69,7 +69,7 @@ AX_SUBDIRS_CONFIGURE([htscodecs],[[--disable-shared],[--with-pic]])
 #       libstaden-read.so.1.1.0
 
 VERS_CURRENT=15
-VERS_REVISION=2
+VERS_REVISION=3
 VERS_AGE=1
 AC_SUBST(VERS_CURRENT)
 AC_SUBST(VERS_REVISION)

--- a/progs/scramble.c
+++ b/progs/scramble.c
@@ -184,7 +184,7 @@ static int filter_tags(bam_seq_t *s, char *aux_filter, int keep) {
 
 static void usage(FILE *fp) {
     fprintf(fp, "  -=- sCRAMble -=-     version %s\n", IOLIB_VERSION);
-    fprintf(fp, "Author: James Bonfield, Wellcome Trust Sanger Institute. 2013-2022\n\n");
+    fprintf(fp, "Author: James Bonfield, Wellcome Trust Sanger Institute. 2013-2023\n\n");
 
     fprintf(fp, "Usage:    scramble [options] [input_file [output_file]]\n");
 
@@ -504,10 +504,6 @@ int main(int argc, char **argv) {
 	fprintf(stderr, "\nWARNING: this version of CRAM is not a recognised GA4GH standard.\n"
 		"Note this CRAM version is a technology demonstration only.\n"
 		"Future versions of Scramble may not be able to read these files.\n\n");
-    } else if (cram_default_version() > 300) {
-	fprintf(stderr, "\nWARNING: this version of CRAM has yet to be formally signed off.\n"
-		"CRAM 3.1 has multiple implementations that have been cross-validated, but\n"
-		"the specification document has not yet been accepted as an official standard.\n\n");
     }
 
     if (argc - optind > 2) {


### PR DESCRIPTION
This removes the warning on CRAM 3.1 being in draft, and updates htscodecs to gain fqzcomp speed improvements.